### PR TITLE
Add expired property to EoxNotice model

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ PLUGINS = ["eox_notices"]
 
 # PLUGINS_CONFIG = {
 #   "eox_notices": {
-#     ADD YOUR SETTINGS HERE
+#     "expired_field": "end_of_support",
 #   }
 # }
 ```
 
-The plugin behavior can be controlled with the following list of settings
+The plugin behavior can be controlled with the following list of settings.
 
-No current behavior can be controlled via `PLUGINS_CONFIG`, but that will most likely change to manage colors for notifications within specific date ranges, etc.
+| Setting       | Default        | Description                                                                                                                                                                                                                           |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| expired_field | end_of_support | The field that will be used to determine if an EoxNotice object is expired. If the field does not exist on the object, it will determine which of the required fields is set and use that. (Either `end_of_support` or `end_of_sale`) |
 
 ## Usage
 

--- a/eox_notices/__init__.py
+++ b/eox_notices/__init__.py
@@ -17,7 +17,7 @@ class EoxNoticesConfig(PluginConfig):
     required_settings = []
     min_version = "1.0.0"
     max_version = "1.9999"
-    default_settings = {}
+    default_settings = {"expired_field": "end_of_support"}
     caching_config = {}
 
     def ready(self):

--- a/eox_notices/api/serializers.py
+++ b/eox_notices/api/serializers.py
@@ -21,6 +21,7 @@ class EoxNoticeSerializer(ValidatedModelSerializer):
         model = EoxNotice
         fields = [
             "id",
+            "expired",
             "devices",
             "device_type",
             "end_of_sale",

--- a/eox_notices/template_content.py
+++ b/eox_notices/template_content.py
@@ -1,18 +1,7 @@
 """Extended core templates for eox_notices."""
 
-from datetime import date
-
 from nautobot.extras.plugins import PluginTemplateExtension
 from .models import EoxNotice
-
-
-def past_due(end_of):
-    """Determine if EoxNotice is past due to change HTML to danger."""
-    today = date.today()
-    if end_of is None:
-        return False
-    if today >= end_of:
-        return True
 
 
 class DeviceEoxNotice(PluginTemplateExtension):
@@ -22,29 +11,13 @@ class DeviceEoxNotice(PluginTemplateExtension):
 
     def right_page(self):
         """Display table on right side of page."""
-        expired = False
         dev_obj = self.context["object"]
         try:
             notice = EoxNotice.objects.get(device_type=dev_obj.device_type.pk)
         except EoxNotice.DoesNotExist:
             notice = None
 
-        # Determine if any of the fields are expired to turn the EoX Notice table in the view red if so.
-        if notice is not None:
-            if list(
-                filter(
-                    past_due,
-                    [
-                        notice.end_of_sale,
-                        notice.end_of_support,
-                        notice.end_of_sw_releases,
-                        notice.end_of_security_patches,
-                    ],
-                )
-            ):
-                expired = True
-
-        return self.render("eox_notices/inc/general_notice.html", extra_context={"notice": notice, "expired": expired})
+        return self.render("eox_notices/inc/general_notice.html", extra_context={"notice": notice})
 
 
 class DeviceTypeEoxNotice(PluginTemplateExtension):
@@ -54,29 +27,13 @@ class DeviceTypeEoxNotice(PluginTemplateExtension):
 
     def right_page(self):
         """Display table on right side of page."""
-        expired = False
         devtype_obj = self.context["object"]
         try:
             notice = EoxNotice.objects.get(device_type=devtype_obj.pk)
         except EoxNotice.DoesNotExist:
             notice = None
 
-        # Determine if any of the fields are expired to turn the EoX Notice table in the view red if so.
-        if notice is not None:
-            if list(
-                filter(
-                    past_due,
-                    [
-                        notice.end_of_sale,
-                        notice.end_of_support,
-                        notice.end_of_sw_releases,
-                        notice.end_of_security_patches,
-                    ],
-                )
-            ):
-                expired = True
-
-        return self.render("eox_notices/inc/general_notice.html", extra_context={"notice": notice, "expired": expired})
+        return self.render("eox_notices/inc/general_notice.html", extra_context={"notice": notice})
 
 
 template_extensions = [DeviceEoxNotice, DeviceTypeEoxNotice]

--- a/eox_notices/templates/eox_notices/inc/general_notice.html
+++ b/eox_notices/templates/eox_notices/inc/general_notice.html
@@ -2,7 +2,7 @@
 {% if perms.eox_notices.view_eoxnotice and notice %}
 <div class="row">
     <div class="col-md-12">
-        {% if expired %}
+        {% if notice.expired %}
         <div class="panel panel-danger">
         {% else %}
         <div class="panel panel-default">

--- a/eox_notices/tests/test_api.py
+++ b/eox_notices/tests/test_api.py
@@ -23,6 +23,7 @@ class EoxNoticeAPITest(APIViewTestCases.APIViewTestCase):
         "end_of_security_patches",
         "end_of_support",
         "end_of_sw_releases",
+        "expired",
         "id",
         "notice_url",
     ]

--- a/eox_notices/views.py
+++ b/eox_notices/views.py
@@ -14,7 +14,6 @@ class EoxNoticesListView(generic.ObjectListView):
     filterset = EoxNoticeFilter
     filterset_form = EoxNoticeFilterForm
     table = EoxNoticesTable
-    # action_buttons = ("add",)
 
     def get_required_permission(self):
         """Return required view permission."""


### PR DESCRIPTION
- Add default plugin configuration (`expired_field = end_of_support`)
- Add expired property that uses `PLUGINS_CONFIG` option
- Update README
- Add necessary tests
- Remove custom logic in `template_content.py` and now uses the `expired` property from the model

TODO:
- [x] Need to see what the API request looks like and makes sure it returns it as well.